### PR TITLE
Add race limit, custom confirm modal and loader

### DIFF
--- a/apps/backend/src/routes/race.routes.ts
+++ b/apps/backend/src/routes/race.routes.ts
@@ -3,10 +3,17 @@ import {Race} from "../models/Race.js";
 
 export default async function raceRoutes(app: FastifyInstance) {
     app.get("/races", async () => {
-        return Race.find().sort({createdAt: -1});
+        const races = await Race.find().sort({createdAt: -1});
+        const count = await Race.countDocuments();
+        return { races, count, limit: 100 };
     });
 
-    app.post("/races", async (req) => {
+    app.post("/races", async (req, reply) => {
+        const count = await Race.countDocuments();
+        if (count >= 100) {
+            return reply.status(400).send({ error: "Limit 100 wyścigów został osiągnięty. Usuń jeden, aby dodać nowy." });
+        }
+
         const { name, startDate } = req.body as any;
         return await Race.create({name, startDate});
     });

--- a/apps/frontend/src/api/RacesApi.ts
+++ b/apps/frontend/src/api/RacesApi.ts
@@ -1,6 +1,6 @@
 import { type Race } from 'types/Race'
 
-const API_URL = import.meta.env.VITE_API_URL
+const API_URL = `${import.meta.env.VITE_API_URL}/races`
 
 interface RacesResponse {
   races: Race[]
@@ -10,12 +10,12 @@ interface RacesResponse {
 
 export const RacesApi = {
   getAll: async (): Promise<RacesResponse> => {
-    const res = await fetch(`${API_URL}/races`)
+    const res = await fetch(API_URL)
     return res.json()
   },
 
   create: async (name: string): Promise<Race> => {
-    const res = await fetch(`${API_URL}/races`, {
+    const res = await fetch(API_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, startDate: new Date().toISOString() }),
@@ -24,6 +24,6 @@ export const RacesApi = {
   },
 
   delete: async (id: string): Promise<void> => {
-    await fetch(`${API_URL}/races/${id}`, { method: 'DELETE' })
+    await fetch(`${API_URL}/${id}`, { method: 'DELETE' })
   },
 }

--- a/apps/frontend/src/api/RacesApi.ts
+++ b/apps/frontend/src/api/RacesApi.ts
@@ -1,6 +1,6 @@
 import { type Race } from 'types/Race'
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api'
+const API_URL = import.meta.env.VITE_API_URL
 
 interface RacesResponse {
   races: Race[]

--- a/apps/frontend/src/api/RacesApi.ts
+++ b/apps/frontend/src/api/RacesApi.ts
@@ -1,0 +1,29 @@
+import { type Race } from 'types/Race'
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api'
+
+interface RacesResponse {
+  races: Race[]
+  count: number
+  limit: number
+}
+
+export const RacesApi = {
+  getAll: async (): Promise<RacesResponse> => {
+    const res = await fetch(`${API_URL}/races`)
+    return res.json()
+  },
+
+  create: async (name: string): Promise<Race> => {
+    const res = await fetch(`${API_URL}/races`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, startDate: new Date().toISOString() }),
+    })
+    return res.json()
+  },
+
+  delete: async (id: string): Promise<void> => {
+    await fetch(`${API_URL}/races/${id}`, { method: 'DELETE' })
+  },
+}

--- a/apps/frontend/src/components/atoms/Loader/Loader.tsx
+++ b/apps/frontend/src/components/atoms/Loader/Loader.tsx
@@ -1,0 +1,29 @@
+import styled, { keyframes } from 'styled-components'
+
+const spin = keyframes`
+  to { transform: rotate(360deg); }
+`
+
+const LoaderWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 32px;
+`
+
+const Spinner = styled.div`
+  width: 32px;
+  height: 32px;
+  border: 3px solid #f3f3f3;
+  border-top: 3px solid #FF1D44;
+  border-radius: 50%;
+  animation: ${spin} 1s linear infinite;
+`
+
+export function Loader() {
+  return (
+    <LoaderWrapper>
+      <Spinner />
+    </LoaderWrapper>
+  )
+}

--- a/apps/frontend/src/components/atoms/TextButton/TextButton.styles.ts
+++ b/apps/frontend/src/components/atoms/TextButton/TextButton.styles.ts
@@ -1,12 +1,12 @@
 import styled from 'styled-components'
 
-export const TextButton = styled.button<{ $variant?: 'primary' | 'secondary' }>`
+export const TextButton = styled.button<{ $variant?: 'primary' | 'secondary' | 'danger' }>`
   font-family: 'Hanken Grotesk', sans-serif;
   font-weight: 600;
   letter-spacing: 0.15em;
   padding: 1rem 3rem;
   font-size: 1rem;
-  background: ${({ $variant }) => $variant === 'secondary' ? 'transparent' : '#FF1D44'};
+  background: ${({ $variant }) => $variant === 'secondary' ? 'transparent' : $variant === 'danger' ? '#dc3545' : '#FF1D44'};
   color: ${({ $variant }) => $variant === 'secondary' ? '#FF1D44' : '#fff'};
   border: ${({ $variant }) => $variant === 'secondary' ? '1px solid #FF1D44' : 'none'};
   border-radius: 4px;
@@ -18,9 +18,9 @@ export const TextButton = styled.button<{ $variant?: 'primary' | 'secondary' }>`
   gap: 0.5rem;
 
   &:hover {
-    background: ${({ $variant }) => $variant === 'secondary' ? '#FF1D44' : '#ff3355'};
+    background: ${({ $variant }) => $variant === 'secondary' ? '#FF1D44' : $variant === 'danger' ? '#c82333' : '#ff3355'};
     color: #fff;
-    box-shadow: 0 0 30px rgba(255, 29, 68, 0.5);
+    box-shadow: ${({ $variant }) => $variant !== 'secondary' ? '0 0 30px rgba(255, 29, 68, 0.5)' : 'none'};
     transform: translateY(-2px);
   }
 

--- a/apps/frontend/src/components/atoms/TextButton/TextButton.tsx
+++ b/apps/frontend/src/components/atoms/TextButton/TextButton.tsx
@@ -1,15 +1,19 @@
-import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react'
 import { TextButton as StyledTextButton } from './TextButton.styles'
 
 interface TextButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode
-  $variant?: 'primary' | 'secondary'
+  $variant?: 'primary' | 'secondary' | 'danger'
 }
 
-export function TextButton({ children, $variant = 'primary', ...props }: TextButtonProps) {
-  return (
-    <StyledTextButton $variant={$variant} {...props}>
-      {children}
-    </StyledTextButton>
-  )
-}
+export const TextButton = forwardRef<HTMLButtonElement, TextButtonProps>(
+  ({ children, $variant = 'primary', ...props }, ref) => {
+    return (
+      <StyledTextButton ref={ref} $variant={$variant} {...props}>
+        {children}
+      </StyledTextButton>
+    )
+  }
+)
+
+TextButton.displayName = 'TextButton'

--- a/apps/frontend/src/components/molecules/ConfirmModal/ConfirmModal.tsx
+++ b/apps/frontend/src/components/molecules/ConfirmModal/ConfirmModal.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react'
+import styled from 'styled-components'
+import { TextButton } from 'components/atoms/TextButton/TextButton'
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+`
+
+const ModalContent = styled.div`
+  background: white;
+  padding: 24px;
+  border-radius: 12px;
+  max-width: 400px;
+  width: 90%;
+  text-align: center;
+`
+
+const ModalTitle = styled.h2`
+  margin: 0 0 16px;
+  font-size: 18px;
+`
+
+const ModalText = styled.p`
+  margin: 0 0 24px;
+  color: #666;
+`
+
+const ModalButtons = styled.div`
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+`
+
+interface ConfirmModalProps {
+  isOpen: boolean
+  title: string
+  message: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmModal({ isOpen, title, message, onConfirm, onCancel }: ConfirmModalProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      cancelRef.current?.focus()
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!isOpen) return
+      if (e.key === 'Escape') {
+        onCancel()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onCancel])
+
+  if (!isOpen) return null
+
+  return (
+    <Overlay onClick={onCancel}>
+      <ModalContent onClick={(e) => e.stopPropagation()}>
+        <ModalTitle>{title}</ModalTitle>
+        <ModalText>{message}</ModalText>
+        <ModalButtons>
+          <TextButton $variant="secondary" ref={cancelRef} onClick={onCancel}>Anuluj</TextButton>
+          <TextButton $variant="danger" onClick={onConfirm}>Usuń</TextButton>
+        </ModalButtons>
+      </ModalContent>
+    </Overlay>
+  )
+}

--- a/apps/frontend/src/components/molecules/ConfirmModal/ConfirmModal.tsx
+++ b/apps/frontend/src/components/molecules/ConfirmModal/ConfirmModal.tsx
@@ -27,6 +27,7 @@ const ModalContent = styled.div`
 const ModalTitle = styled.h2`
   margin: 0 0 16px;
   font-size: 18px;
+  color: #000;
 `
 
 const ModalText = styled.p`

--- a/apps/frontend/src/components/molecules/RaceItem/RaceItem.tsx
+++ b/apps/frontend/src/components/molecules/RaceItem/RaceItem.tsx
@@ -41,8 +41,8 @@ export function RaceItem({ race, onDelete, onOpen }: RaceItemProps) {
       </RaceItemContainer>
       <ConfirmModal
         isOpen={showConfirm}
-        title={tCommon('delete-confirm-title') || 'Usuń wyścig'}
-        message={tCommon('confirm-delete') || 'Czy na pewno chcesz usunąć ten wyścig?'}
+        title={tCommon('delete-confirm-title')}
+        message={tCommon('confirm-delete')}
         onConfirm={handleConfirm}
         onCancel={() => setShowConfirm(false)}
       />

--- a/apps/frontend/src/components/molecules/RaceItem/RaceItem.tsx
+++ b/apps/frontend/src/components/molecules/RaceItem/RaceItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TextButton } from 'components/atoms/TextButton/TextButton'
 import { IconButton } from 'components/atoms/IconButton/IconButton'
@@ -18,14 +18,18 @@ export function RaceItem({ race, onDelete, onOpen }: RaceItemProps) {
   const { t: tCommon } = useTranslation('common')
   const [showConfirm, setShowConfirm] = useState(false)
 
-  const handleDelete = () => {
+  const handleDelete = useCallback(() => {
     setShowConfirm(true)
-  }
+  }, [])
 
-  const handleConfirm = () => {
+  const handleConfirm = useCallback(() => {
     onDelete(race._id)
     setShowConfirm(false)
-  }
+  }, [onDelete, race._id])
+
+  const handleCancel = useCallback(() => {
+    setShowConfirm(false)
+  }, [])
 
   return (
     <>
@@ -44,7 +48,7 @@ export function RaceItem({ race, onDelete, onOpen }: RaceItemProps) {
         title={tCommon('delete-confirm-title')}
         message={tCommon('confirm-delete')}
         onConfirm={handleConfirm}
-        onCancel={() => setShowConfirm(false)}
+        onCancel={handleCancel}
       />
     </>
   )

--- a/apps/frontend/src/components/molecules/RaceItem/RaceItem.tsx
+++ b/apps/frontend/src/components/molecules/RaceItem/RaceItem.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TextButton } from 'components/atoms/TextButton/TextButton'
 import { IconButton } from 'components/atoms/IconButton/IconButton'
+import {ConfirmModal} from 'components/molecules/ConfirmModal/ConfirmModal'
 import {RaceActions, RaceDate, RaceInfo, RaceItemContainer, RaceName} from './RaceItem.styles'
 import { type Race } from 'types/Race'
 import TrashIcon from 'assets/svg/trash.svg'
@@ -14,17 +16,36 @@ interface RaceItemProps {
 export function RaceItem({ race, onDelete, onOpen }: RaceItemProps) {
   const { t } = useTranslation('home')
   const { t: tCommon } = useTranslation('common')
+  const [showConfirm, setShowConfirm] = useState(false)
+
+  const handleDelete = () => {
+    setShowConfirm(true)
+  }
+
+  const handleConfirm = () => {
+    onDelete(race._id)
+    setShowConfirm(false)
+  }
 
   return (
-    <RaceItemContainer>
-      <RaceInfo>
-        <RaceName>{race.name}</RaceName>
-        <RaceDate>{new Date(race.createdAt).toLocaleDateString('pl-PL')}</RaceDate>
-      </RaceInfo>
-      <RaceActions>
-        <TextButton onClick={() => onOpen(race._id)} $variant="secondary">{t('open-race')}</TextButton>
-        <IconButton onClick={() => onDelete(race._id)} title={tCommon('delete')} icon={TrashIcon} />
-      </RaceActions>
-    </RaceItemContainer>
+    <>
+      <RaceItemContainer>
+        <RaceInfo>
+          <RaceName>{race.name}</RaceName>
+          <RaceDate>{new Date(race.createdAt).toLocaleDateString('pl-PL')}</RaceDate>
+        </RaceInfo>
+        <RaceActions>
+          <TextButton onClick={() => onOpen(race._id)} $variant="secondary">{t('open-race')}</TextButton>
+          <IconButton onClick={handleDelete} title={tCommon('delete')} icon={TrashIcon} />
+        </RaceActions>
+      </RaceItemContainer>
+      <ConfirmModal
+        isOpen={showConfirm}
+        title={tCommon('delete-confirm-title') || 'Usuń wyścig'}
+        message={tCommon('confirm-delete') || 'Czy na pewno chcesz usunąć ten wyścig?'}
+        onConfirm={handleConfirm}
+        onCancel={() => setShowConfirm(false)}
+      />
+    </>
   )
 }

--- a/apps/frontend/src/components/organisms/RacesDashboard/RacesDashboard.styles.ts
+++ b/apps/frontend/src/components/organisms/RacesDashboard/RacesDashboard.styles.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components'
+
+export const DashboardContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`
+
+export const LimitBadge = styled.span`
+  font-size: 14px;
+  color: #666;
+  font-weight: 500;
+`

--- a/apps/frontend/src/components/organisms/RacesDashboard/RacesDashboard.tsx
+++ b/apps/frontend/src/components/organisms/RacesDashboard/RacesDashboard.tsx
@@ -1,7 +1,9 @@
 import { useState, useCallback, useEffect } from 'react'
 import { RaceInputGroup } from 'components/molecules/RaceInputGroup/RaceInputGroup'
 import { RacesList } from 'components/molecules/RacesList/RacesList'
+import { Loader } from 'components/atoms/Loader/Loader'
 import { type Race } from 'types/Race'
+import { DashboardContainer, LimitBadge } from './RacesDashboard.styles'
 
 interface RacesDashboardProps {
   initialRaces?: Race[]
@@ -11,11 +13,17 @@ const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api'
 
 export function RacesDashboard({ initialRaces }: RacesDashboardProps) {
   const [races, setRaces] = useState<Race[]>(initialRaces ?? [])
+  const [raceCount, setRaceCount] = useState(0)
+  const [raceLimit] = useState(100)
+  const [loading, setLoading] = useState(true)
 
   const fetchRaces = useCallback(async () => {
+    setLoading(true)
     const res = await fetch(`${API_URL}/races`)
     const data = await res.json()
-    setRaces(data)
+    setRaces(data.races)
+    setRaceCount(data.count)
+    setLoading(false)
   }, [])
 
   useEffect(() => {
@@ -43,9 +51,10 @@ export function RacesDashboard({ initialRaces }: RacesDashboardProps) {
   }, [])
 
   return (
-    <>
+    <DashboardContainer>
       <RaceInputGroup onAdd={handleAdd} />
-      <RacesList races={races} onDelete={handleDelete} onOpen={handleOpen} />
-    </>
+      {loading ? <Loader /> : <RacesList races={races} onDelete={handleDelete} onOpen={handleOpen} />}
+      <LimitBadge>{raceCount}/{raceLimit}</LimitBadge>
+    </DashboardContainer>
   )
 }

--- a/apps/frontend/src/components/organisms/RacesDashboard/RacesDashboard.tsx
+++ b/apps/frontend/src/components/organisms/RacesDashboard/RacesDashboard.tsx
@@ -2,14 +2,13 @@ import { useState, useCallback, useEffect } from 'react'
 import { RaceInputGroup } from 'components/molecules/RaceInputGroup/RaceInputGroup'
 import { RacesList } from 'components/molecules/RacesList/RacesList'
 import { Loader } from 'components/atoms/Loader/Loader'
+import { RacesApi } from 'api/RacesApi'
 import { type Race } from 'types/Race'
 import { DashboardContainer, LimitBadge } from './RacesDashboard.styles'
 
 interface RacesDashboardProps {
   initialRaces?: Race[]
 }
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000/api'
 
 export function RacesDashboard({ initialRaces }: RacesDashboardProps) {
   const [races, setRaces] = useState<Race[]>(initialRaces ?? [])
@@ -19,8 +18,7 @@ export function RacesDashboard({ initialRaces }: RacesDashboardProps) {
 
   const fetchRaces = useCallback(async () => {
     setLoading(true)
-    const res = await fetch(`${API_URL}/races`)
-    const data = await res.json()
+    const data = await RacesApi.getAll()
     setRaces(data.races)
     setRaceCount(data.count)
     setLoading(false)
@@ -32,17 +30,13 @@ export function RacesDashboard({ initialRaces }: RacesDashboardProps) {
 
   const handleAdd = useCallback(async (raceName: string) => {
     if (raceName.trim()) {
-      await fetch(`${API_URL}/races`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: raceName, startDate: new Date().toISOString() }),
-      })
+      await RacesApi.create(raceName)
       await fetchRaces()
     }
   }, [fetchRaces])
 
   const handleDelete = useCallback(async (id: string) => {
-    await fetch(`${API_URL}/races/${id}`, { method: 'DELETE' })
+    await RacesApi.delete(id)
     await fetchRaces()
   }, [fetchRaces])
 

--- a/apps/frontend/src/i18n/locales/en/common.json
+++ b/apps/frontend/src/i18n/locales/en/common.json
@@ -8,5 +8,7 @@
   "close": "Close",
   "loading": "Loading...",
   "error": "Error",
-  "success": "Success"
+  "success": "Success",
+  "confirm-delete": "Are you sure you want to delete this race?",
+  "delete-confirm-title": "Delete race"
 }

--- a/apps/frontend/src/i18n/locales/pl/common.json
+++ b/apps/frontend/src/i18n/locales/pl/common.json
@@ -8,5 +8,7 @@
   "close": "Zamknij",
   "loading": "Ładowanie...",
   "error": "Błąd",
-  "success": "Sukces"
+  "success": "Sukces",
+  "confirm-delete": "Czy na pewno chcesz usunąć ten wyścig?",
+  "delete-confirm-title": "Usuń wyścig"
 }

--- a/apps/frontend/tsconfig.app.json
+++ b/apps/frontend/tsconfig.app.json
@@ -28,6 +28,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
+      "api/*": ["./src/api/*"],
       "components/*": ["./src/components/*"],
       "pages/*": ["./src/pages/*"],
       "assets/*": ["./src/assets/*"],

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      'api': path.resolve(__dirname, './src/api'),
       components: path.resolve(__dirname, './src/components'),
       pages: path.resolve(__dirname, './src/pages'),
       assets: path.resolve(__dirname, './src/assets'),


### PR DESCRIPTION
## Summary
- Add 100 race limit to prevent MongoDB free tier overflow
- Display race count (x/100) below races list
- Create custom ConfirmModal component instead of browser confirm dialog
- Add Loader component for loading states
- Configure frontend to use VITE_API_URL environment variable for easier deployment