### PR TITLE
feat: race edit modal with real-time sync

### DIFF
--- a/apps/backend/src/models/Race.ts
+++ b/apps/backend/src/models/Race.ts
@@ -3,7 +3,13 @@ import { Schema, model, Types } from "mongoose";
 const RaceSchema = new Schema(
     {
         name: { type: String, required: true },
-        startDate: { type: Date, required: true }
+        startDate: { type: Date, required: true },
+        raceLength: { type: Number, default: 6 },
+        drivers: [{ type: String }],
+        tireSets: { type: Number, default: 0 },
+        avgLapTime: { type: Number, default: 0 },
+        avgFuelPerLap: { type: Number, default: 0 },
+        avgStintTime: { type: Number, default: 0 }
     },
     { timestamps: true }
 );

--- a/apps/backend/src/routes/race.routes.ts
+++ b/apps/backend/src/routes/race.routes.ts
@@ -1,5 +1,6 @@
 import {FastifyInstance} from "fastify";
 import {Race} from "../models/Race.js";
+import {getIO} from "../socket.js";
 
 export default async function raceRoutes(app: FastifyInstance) {
     app.get("/races", async () => {
@@ -30,6 +31,28 @@ export default async function raceRoutes(app: FastifyInstance) {
         if (!race) {
             return reply.status(404).send({ error: "Wyścig nie znaleziony" });
         }
+        return race;
+    });
+
+    app.patch("/races/:id", async (req, reply) => {
+        const { id } = req.params as any;
+        const patch = req.body as Partial<typeof Race>;
+        
+        const race = await Race.findByIdAndUpdate(
+            id,
+            { $set: patch },
+            { new: true }
+        );
+        
+        if (!race) {
+            return reply.status(404).send({ error: "Wyścig nie znaleziony" });
+        }
+
+        const io = getIO();
+        if (io) {
+            io.emit("race:updated", race);
+        }
+        
         return race;
     });
 }

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -9,7 +9,7 @@ export function buildServer() {
     const app = Fastify({ logger: true });
 
     app.register(cors, {
-        methods: ['GET', 'POST', 'PUT', 'DELETE']
+        methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']
     });
 
     app.register(swagger, {

--- a/apps/backend/src/socket.ts
+++ b/apps/backend/src/socket.ts
@@ -1,8 +1,15 @@
 import { Server } from "socket.io";
 import { Stint } from "./models/Stint.js";
+import { Race } from "./models/Race.js";
+
+let io: Server;
+
+export function getIO() {
+    return io;
+}
 
 export function initSocket(httpServer: any) {
-    const io = new Server(httpServer, {
+    io = new Server(httpServer, {
         cors: { origin: "*" }
     });
 
@@ -42,6 +49,17 @@ export function initSocket(httpServer: any) {
             await stint.save();
 
             io.emit("stint:unlocked", stintId);
+        });
+
+        socket.on("race:update", async ({ raceId, patch }) => {
+            const race = await Race.findByIdAndUpdate(
+                raceId,
+                { $set: patch },
+                { new: true }
+            );
+            if (!race) return;
+
+            io.emit("race:updated", race);
         });
 
         socket.on("disconnect", async () => {

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -1,0 +1,1000 @@
+{
+  "name": "frontend",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "frontend",
+      "version": "0.0.0",
+      "dependencies": {
+        "i18next": "^25.8.13",
+        "i18next-browser-languagedetector": "^8.2.1",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+        "react-i18next": "^16.5.4",
+        "react-router-dom": "^7.13.1",
+        "socket.io-client": "^4.8.3",
+        "styled-components": "^6.3.11"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.1",
+        "@types/node": "^24.10.1",
+        "@types/react": "^19.2.5",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.1.1",
+        "eslint": "^9.39.1",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-refresh": "^0.4.24",
+        "globals": "^16.5.0",
+        "typescript": "~5.9.3",
+        "typescript-eslint": "^8.46.4",
+        "vite": "^7.2.4"
+      }
+    },
+    "../../node_modules/.pnpm/@eslint+js@9.39.2/node_modules/@eslint/js": {
+      "version": "9.39.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "../../node_modules/.pnpm/@types+node@24.10.7/node_modules/@types/node": {
+      "version": "24.10.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "../../node_modules/.pnpm/@types+react-dom@19.2.3_@types+react@19.2.8/node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "../../node_modules/.pnpm/@types+react@19.2.8/node_modules/@types/react": {
+      "version": "19.2.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "../../node_modules/.pnpm/@vitejs+plugin-react@5.1.2_vite@7.3.1_@types+node@24.10.7_jiti@2.6.1_lightningcss@1.30.2_tsx@4.21.0_yaml@2.8.2_/node_modules/@vitejs/plugin-react": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.5",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.53",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "devDependencies": {
+        "@vitejs/react-common": "workspace:*",
+        "babel-plugin-react-compiler": "19.1.0-rc.3",
+        "react": "^19.2.1",
+        "react-dom": "^19.2.1",
+        "rolldown": "1.0.0-beta.53",
+        "tsdown": "^0.17.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "../../node_modules/.pnpm/eslint-plugin-react-hooks@7.0.1_eslint@9.39.2_jiti@2.6.1_/node_modules/eslint-plugin-react-hooks": {
+      "version": "7.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "devDependencies": {
+        "@babel/eslint-parser": "^7.11.4",
+        "@babel/preset-typescript": "^7.26.0",
+        "@babel/types": "^7.19.0",
+        "@tsconfig/strictest": "^2.0.5",
+        "@types/eslint": "^9.6.1",
+        "@types/estree": "^1.0.6",
+        "@types/estree-jsx": "^1.0.5",
+        "@types/node": "^20.2.5",
+        "@typescript-eslint/parser-v2": "npm:@typescript-eslint/parser@^2.26.0",
+        "@typescript-eslint/parser-v3": "npm:@typescript-eslint/parser@^3.10.0",
+        "@typescript-eslint/parser-v4": "npm:@typescript-eslint/parser@^4.1.0",
+        "@typescript-eslint/parser-v5": "npm:@typescript-eslint/parser@^5.62.0",
+        "babel-eslint": "^10.0.3",
+        "eslint-v7": "npm:eslint@^7.7.0",
+        "eslint-v8": "npm:eslint@^8.57.1",
+        "eslint-v9": "npm:eslint@^9.0.0",
+        "jest": "^29.5.0",
+        "typescript": "^5.4.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "../../node_modules/.pnpm/eslint-plugin-react-refresh@0.4.26_eslint@9.39.2_jiti@2.6.1_/node_modules/eslint-plugin-react-refresh": {
+      "version": "0.4.26",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=8.40"
+      }
+    },
+    "../../node_modules/.pnpm/eslint@9.39.2_jiti@2.6.1/node_modules/eslint": {
+      "version": "9.39.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.2",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "devDependencies": {
+        "@arethetypeswrong/cli": "^0.18.0",
+        "@babel/core": "^7.4.3",
+        "@babel/preset-env": "^7.4.3",
+        "@cypress/webpack-preprocessor": "^6.0.2",
+        "@eslint/json": "^0.13.2",
+        "@trunkio/launcher": "^1.3.4",
+        "@types/esquery": "^1.5.4",
+        "@types/node": "^22.13.14",
+        "@typescript-eslint/parser": "^8.4.0",
+        "babel-loader": "^8.0.5",
+        "c8": "^7.12.0",
+        "chai": "^4.0.1",
+        "cheerio": "^0.22.0",
+        "common-tags": "^1.8.0",
+        "core-js": "^3.1.3",
+        "cypress": "^14.1.0",
+        "ejs": "^3.0.2",
+        "eslint": "file:.",
+        "eslint-config-eslint": "file:packages/eslint-config-eslint",
+        "eslint-plugin-eslint-plugin": "^6.0.0",
+        "eslint-plugin-expect-type": "^0.6.0",
+        "eslint-plugin-yml": "^1.14.0",
+        "eslint-release": "^3.3.0",
+        "eslint-rule-composer": "^0.3.0",
+        "eslump": "^3.0.0",
+        "esprima": "^4.0.1",
+        "fast-glob": "^3.2.11",
+        "fs-teardown": "^0.1.3",
+        "glob": "^10.0.0",
+        "globals": "^16.2.0",
+        "got": "^11.8.3",
+        "gray-matter": "^4.0.3",
+        "jiti": "^2.6.1",
+        "jiti-v2.0": "npm:jiti@2.0.x",
+        "jiti-v2.1": "npm:jiti@2.1.x",
+        "knip": "^5.60.2",
+        "lint-staged": "^11.0.0",
+        "markdown-it": "^12.2.0",
+        "markdown-it-container": "^3.0.0",
+        "marked": "^4.0.8",
+        "metascraper": "^5.25.7",
+        "metascraper-description": "^5.25.7",
+        "metascraper-image": "^5.29.3",
+        "metascraper-logo": "^5.25.7",
+        "metascraper-logo-favicon": "^5.25.7",
+        "metascraper-title": "^5.25.7",
+        "mocha": "^11.7.1",
+        "node-polyfill-webpack-plugin": "^1.0.3",
+        "npm-license": "^0.3.3",
+        "pirates": "^4.0.5",
+        "progress": "^2.0.3",
+        "proxyquire": "^2.0.1",
+        "recast": "^0.23.0",
+        "regenerator-runtime": "^0.14.0",
+        "semver": "^7.5.3",
+        "shelljs": "^0.10.0",
+        "sinon": "^11.0.0",
+        "typescript": "^5.3.3",
+        "webpack": "^5.23.0",
+        "webpack-cli": "^4.5.0",
+        "yorkie": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/globals@16.5.0/node_modules/globals": {
+      "version": "16.5.0",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/eslint-plugin": "^1.1.44",
+        "ava": "^6.3.0",
+        "cheerio": "^1.0.0",
+        "eslint-plugin-jest": "^28.11.0",
+        "get-port": "^7.1.0",
+        "is-identifier": "^1.0.1",
+        "nano-spawn": "^0.2.0",
+        "npm-run-all2": "^8.0.1",
+        "outdent": "^0.8.0",
+        "puppeteer": "^24.27.0",
+        "shelljs": "^0.9.2",
+        "tsd": "^0.32.0",
+        "type-fest": "^4.41.0",
+        "xo": "^0.60.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../node_modules/.pnpm/i18next-browser-languagedetector@8.2.1/node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.23.3",
+        "@babel/eslint-parser": "^7.23.3",
+        "@babel/plugin-transform-runtime": "^7.23.3",
+        "@babel/preset-env": "^7.23.3",
+        "@rollup/plugin-babel": "^5.3.1",
+        "@rollup/plugin-node-resolve": "^14.1.0",
+        "babel-polyfill": "^6.26.0",
+        "babelify": "^10.0.0",
+        "browserify": "17.0.0",
+        "browserify-istanbul": "3.0.1",
+        "chai": "4.3.10",
+        "coveralls": "3.1.1",
+        "cpy-cli": "^5.0.0",
+        "dtslint": "^4.2.1",
+        "eslint": "8.53.0",
+        "eslint-config-airbnb": "19.0.4",
+        "expect.js": "0.3.1",
+        "i18next": "23.7.1",
+        "mkdirp": "3.0.1",
+        "mocha": "10.8.2",
+        "rimraf": "5.0.5",
+        "rollup": "^2.79.1",
+        "rollup-plugin-terser": "^7.0.2",
+        "tsd": "0.29.0",
+        "tslint": "^5.20.1",
+        "typescript": "5.1.3",
+        "yargs": "17.7.2"
+      }
+    },
+    "../../node_modules/.pnpm/i18next@25.8.13_typescript@5.9.3/node_modules/i18next": {
+      "version": "25.8.13",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "devDependencies": {
+        "@arktype/attest": "^0.55.0",
+        "@babel/core": "^7.28.5",
+        "@babel/plugin-transform-async-generator-functions": "^7.28.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-runtime": "^7.28.5",
+        "@babel/polyfill": "^7.12.1",
+        "@babel/preset-env": "^7.28.5",
+        "@babel/preset-react": "^7.28.5",
+        "@babel/register": "^7.28.3",
+        "@rollup/plugin-babel": "^6.1.0",
+        "@rollup/plugin-commonjs": "^29.0.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-terser": "^0.4.4",
+        "@types/node": "^22.19.1",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
+        "@vitest/coverage-v8": "^3.2.4",
+        "babelify": "^10.0.0",
+        "coveralls": "^3.1.1",
+        "cpy-cli": "^5.0.0",
+        "eslint": "^8.57.1",
+        "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-import-resolver-typescript": "^4.4.4",
+        "eslint-plugin-import": "^2.32.0",
+        "gh-release": "^7.0.2",
+        "husky": "^9.1.7",
+        "i18next-browser-languagedetector": "^8.2.0",
+        "i18next-fs-backend": "^2.6.1",
+        "i18next-http-backend": "^3.0.2",
+        "i18next-localstorage-cache": "^1.1.1",
+        "i18next-sprintf-postprocessor": "^0.2.2",
+        "lint-staged": "^16.2.6",
+        "prettier": "^3.6.2",
+        "rimraf": "^6.1.0",
+        "rollup": "^4.53.2",
+        "sinon": "^19.0.5",
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom": {
+      "version": "19.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.3"
+      }
+    },
+    "../../node_modules/.pnpm/react-i18next@16.5.4_i18next@25.8.13_typescript@5.9.3__react-dom@19.2.3_react@19.2.3__react@19.2.3_typescript@5.9.3/node_modules/react-i18next": {
+      "version": "16.5.4",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.28.3",
+        "@babel/core": "^7.28.5",
+        "@babel/eslint-parser": "^7.28.5",
+        "@babel/plugin-proposal-async-generator-functions": "^7.20.7",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-runtime": "^7.28.5",
+        "@babel/polyfill": "^7.12.1",
+        "@babel/preset-env": "^7.28.5",
+        "@babel/preset-react": "^7.28.5",
+        "@babel/register": "^7.28.3",
+        "@rollup/plugin-babel": "^6.1.0",
+        "@rollup/plugin-commonjs": "^26.0.3",
+        "@rollup/plugin-node-resolve": "^15.3.1",
+        "@rollup/plugin-replace": "^5.0.7",
+        "@rollup/plugin-terser": "0.4.4",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.1",
+        "@types/jest": "^29.5.12",
+        "@types/react": "^19.2.7",
+        "@vitest/coverage-v8": "^2.0.5",
+        "all-contributors-cli": "^6.26.1",
+        "babel-core": "^7.0.0-bridge.0",
+        "babel-plugin-macros": "^3.1.0",
+        "babel-plugin-tester": "^11.0.4",
+        "coveralls": "^3.1.1",
+        "cpy-cli": "^5.0.0",
+        "cross-env": "^7.0.3",
+        "eslint": "^8.57.0",
+        "eslint-config-airbnb": "19.0.4",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jest-dom": "^5.5.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-testing-library": "^6.5.0",
+        "happy-dom": "^14.12.3",
+        "husky": "^9.1.7",
+        "i18next": "^25.7.3",
+        "lint-staged": "^15.5.2",
+        "mkdirp": "^3.0.1",
+        "prettier": "^3.7.4",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
+        "react-test-renderer": "^19.2.3",
+        "rimraf": "^6.1.2",
+        "rollup": "^4.54.0",
+        "typescript": "~5.9.3",
+        "vitest": "^2.0.5",
+        "yargs": "^17.7.2"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.6.2",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/react-router-dom@7.13.1_react-dom@19.2.3_react@19.2.3__react@19.2.3/node_modules/react-router-dom": {
+      "version": "7.13.1",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.1"
+      },
+      "devDependencies": {
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
+        "tsup": "^8.3.0",
+        "typescript": "^5.4.5",
+        "wireit": "0.14.9"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "../../node_modules/.pnpm/react@19.2.3/node_modules/react": {
+      "version": "19.2.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../node_modules/.pnpm/styled-components@6.3.11_react-dom@19.2.3_react@19.2.3__react@19.2.3/node_modules/styled-components": {
+      "version": "6.3.11",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.4.0",
+        "@emotion/unitless": "0.10.0",
+        "@types/stylis": "4.2.7",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.2.3",
+        "postcss": "8.4.49",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.6",
+        "tslib": "2.8.1"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.24.5",
+        "@babel/helper-module-imports": "^7.24.3",
+        "@babel/plugin-external-helpers": "^7.24.1",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/plugin-transform-flow-strip-types": "^7.24.1",
+        "@babel/preset-env": "^7.24.5",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/preset-typescript": "^7.24.1",
+        "@rollup/plugin-typescript": "^11.1.6",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.8.0",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/enzyme": "^3.10.18",
+        "@types/jest": "^30.0.0",
+        "@types/js-beautify": "^1.14.3",
+        "@types/node": "^18.19.31",
+        "@types/react": "^18",
+        "@types/react-dom": "^18",
+        "@types/react-frame-component": "^4.1.6",
+        "@types/react-native": "^0.71",
+        "@types/react-test-renderer": "^18.0.0",
+        "@types/shallowequal": "^1.1.5",
+        "babel-jest": "^30.1.2",
+        "babel-plugin-add-module-exports": "^1.0.4",
+        "babel-plugin-styled-components": "^2.1.4",
+        "babel-plugin-tester": "^10.1.0",
+        "bundlewatch": "^0.4.1",
+        "jest": "^30.1.3",
+        "jest-environment-jsdom": "^30.1.2",
+        "jest-serializer-html": "^7.1.0",
+        "jest-watch-typeahead": "^3.0.1",
+        "js-beautify": "^1.15.1",
+        "prettier": "^3.6.2",
+        "prop-types": "^15.8.1",
+        "react": "^18",
+        "react-dom": "^18",
+        "react-frame-component": "^4.1.3",
+        "react-native": "~0.71",
+        "react-test-renderer": "^18.0.0",
+        "rollup": "^3.29.4",
+        "rollup-plugin-commonjs": "^10.1.0",
+        "rollup-plugin-json": "^4.0.0",
+        "rollup-plugin-node-resolve": "^5.2.0",
+        "rollup-plugin-replace": "^2.2.0",
+        "rollup-plugin-sourcemaps": "^0.6.3",
+        "rollup-plugin-terser": "^7.0.2",
+        "stylis-plugin-rtl": "^2.1.1",
+        "ts-toolbelt": "^9.6.0",
+        "typescript": "^5.4.5"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/typescript-eslint@8.53.0_eslint@9.39.2_jiti@2.6.1__typescript@5.9.3/node_modules/typescript-eslint": {
+      "version": "8.53.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.53.0",
+        "@typescript-eslint/parser": "8.53.0",
+        "@typescript-eslint/typescript-estree": "8.53.0",
+        "@typescript-eslint/utils": "8.53.0"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^3.2.4",
+        "eslint": "*",
+        "rimraf": "*",
+        "typescript": "*",
+        "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript": {
+      "version": "5.9.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "devDependencies": {
+        "@dprint/formatter": "^0.4.1",
+        "@dprint/typescript": "0.93.4",
+        "@esfx/canceltoken": "^1.0.0",
+        "@eslint/js": "^9.20.0",
+        "@octokit/rest": "^21.1.1",
+        "@types/chai": "^4.3.20",
+        "@types/diff": "^7.0.1",
+        "@types/minimist": "^1.2.5",
+        "@types/mocha": "^10.0.10",
+        "@types/ms": "^0.7.34",
+        "@types/node": "latest",
+        "@types/source-map-support": "^0.5.10",
+        "@types/which": "^3.0.4",
+        "@typescript-eslint/rule-tester": "^8.24.1",
+        "@typescript-eslint/type-utils": "^8.24.1",
+        "@typescript-eslint/utils": "^8.24.1",
+        "azure-devops-node-api": "^14.1.0",
+        "c8": "^10.1.3",
+        "chai": "^4.5.0",
+        "chokidar": "^4.0.3",
+        "diff": "^7.0.0",
+        "dprint": "^0.49.0",
+        "esbuild": "^0.25.0",
+        "eslint": "^9.20.1",
+        "eslint-formatter-autolinkable-stylish": "^1.4.0",
+        "eslint-plugin-regexp": "^2.7.0",
+        "fast-xml-parser": "^4.5.2",
+        "glob": "^10.4.5",
+        "globals": "^15.15.0",
+        "hereby": "^1.10.0",
+        "jsonc-parser": "^3.3.1",
+        "knip": "^5.44.4",
+        "minimist": "^1.2.8",
+        "mocha": "^10.8.2",
+        "mocha-fivemat-progress-reporter": "^0.1.0",
+        "monocart-coverage-reports": "^2.12.1",
+        "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
+        "playwright": "^1.50.1",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.8.1",
+        "typescript": "^5.7.3",
+        "typescript-eslint": "^8.24.1",
+        "which": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "../../node_modules/.pnpm/vite@7.3.1_@types+node@24.10.7_jiti@2.6.1_lightningcss@1.30.2_tsx@4.21.0_yaml@2.8.2/node_modules/vite": {
+      "version": "7.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "devDependencies": {
+        "@babel/parser": "^7.28.5",
+        "@jridgewell/remapping": "^2.3.5",
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "@oxc-project/types": "0.95.0",
+        "@polka/compression": "^1.0.0-next.25",
+        "@rolldown/pluginutils": "^1.0.0-beta.52",
+        "@rollup/plugin-alias": "^5.1.1",
+        "@rollup/plugin-commonjs": "^29.0.0",
+        "@rollup/plugin-dynamic-import-vars": "2.1.4",
+        "@rollup/pluginutils": "^5.3.0",
+        "@types/escape-html": "^1.0.4",
+        "@types/pnpapi": "^0.0.5",
+        "artichokie": "^0.4.2",
+        "baseline-browser-mapping": "^2.8.32",
+        "cac": "^6.7.14",
+        "chokidar": "^3.6.0",
+        "connect": "^3.7.0",
+        "convert-source-map": "^2.0.0",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^17.2.3",
+        "dotenv-expand": "^12.0.3",
+        "es-module-lexer": "^1.7.0",
+        "escape-html": "^1.0.3",
+        "estree-walker": "^3.0.3",
+        "etag": "^1.8.1",
+        "host-validation-middleware": "^0.1.2",
+        "http-proxy-3": "^1.22.0",
+        "launch-editor-middleware": "^2.12.0",
+        "lightningcss": "^1.30.2",
+        "magic-string": "^0.30.21",
+        "mlly": "^1.8.0",
+        "mrmime": "^2.0.1",
+        "nanoid": "^5.1.6",
+        "obug": "^1.0.2",
+        "open": "^10.2.0",
+        "parse5": "^8.0.0",
+        "pathe": "^2.0.3",
+        "periscopic": "^4.0.2",
+        "picocolors": "^1.1.1",
+        "postcss-import": "^16.1.1",
+        "postcss-load-config": "^6.0.1",
+        "postcss-modules": "^6.0.1",
+        "premove": "^4.0.0",
+        "resolve.exports": "^2.0.3",
+        "rolldown": "^1.0.0-beta.52",
+        "rolldown-plugin-dts": "^0.18.1",
+        "rollup-plugin-license": "^3.6.0",
+        "sass": "^1.94.2",
+        "sass-embedded": "^1.93.3",
+        "sirv": "^3.0.2",
+        "strip-literal": "^3.1.0",
+        "terser": "^5.44.1",
+        "tsconfck": "^3.1.6",
+        "ufo": "^1.6.1",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/js": {
+      "resolved": "../../node_modules/.pnpm/@eslint+js@9.39.2/node_modules/@eslint/js",
+      "link": true
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "resolved": "../../node_modules/.pnpm/@types+node@24.10.7/node_modules/@types/node",
+      "link": true
+    },
+    "node_modules/@types/react": {
+      "resolved": "../../node_modules/.pnpm/@types+react@19.2.8/node_modules/@types/react",
+      "link": true
+    },
+    "node_modules/@types/react-dom": {
+      "resolved": "../../node_modules/.pnpm/@types+react-dom@19.2.3_@types+react@19.2.8/node_modules/@types/react-dom",
+      "link": true
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "resolved": "../../node_modules/.pnpm/@vitejs+plugin-react@5.1.2_vite@7.3.1_@types+node@24.10.7_jiti@2.6.1_lightningcss@1.30.2_tsx@4.21.0_yaml@2.8.2_/node_modules/@vitejs/plugin-react",
+      "link": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/eslint": {
+      "resolved": "../../node_modules/.pnpm/eslint@9.39.2_jiti@2.6.1/node_modules/eslint",
+      "link": true
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "resolved": "../../node_modules/.pnpm/eslint-plugin-react-hooks@7.0.1_eslint@9.39.2_jiti@2.6.1_/node_modules/eslint-plugin-react-hooks",
+      "link": true
+    },
+    "node_modules/eslint-plugin-react-refresh": {
+      "resolved": "../../node_modules/.pnpm/eslint-plugin-react-refresh@0.4.26_eslint@9.39.2_jiti@2.6.1_/node_modules/eslint-plugin-react-refresh",
+      "link": true
+    },
+    "node_modules/globals": {
+      "resolved": "../../node_modules/.pnpm/globals@16.5.0/node_modules/globals",
+      "link": true
+    },
+    "node_modules/i18next": {
+      "resolved": "../../node_modules/.pnpm/i18next@25.8.13_typescript@5.9.3/node_modules/i18next",
+      "link": true
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "resolved": "../../node_modules/.pnpm/i18next-browser-languagedetector@8.2.1/node_modules/i18next-browser-languagedetector",
+      "link": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "resolved": "../../node_modules/.pnpm/react@19.2.3/node_modules/react",
+      "link": true
+    },
+    "node_modules/react-dom": {
+      "resolved": "../../node_modules/.pnpm/react-dom@19.2.3_react@19.2.3/node_modules/react-dom",
+      "link": true
+    },
+    "node_modules/react-i18next": {
+      "resolved": "../../node_modules/.pnpm/react-i18next@16.5.4_i18next@25.8.13_typescript@5.9.3__react-dom@19.2.3_react@19.2.3__react@19.2.3_typescript@5.9.3/node_modules/react-i18next",
+      "link": true
+    },
+    "node_modules/react-router-dom": {
+      "resolved": "../../node_modules/.pnpm/react-router-dom@7.13.1_react-dom@19.2.3_react@19.2.3__react@19.2.3/node_modules/react-router-dom",
+      "link": true
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-components": {
+      "resolved": "../../node_modules/.pnpm/styled-components@6.3.11_react-dom@19.2.3_react@19.2.3__react@19.2.3/node_modules/styled-components",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "resolved": "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript",
+      "link": true
+    },
+    "node_modules/typescript-eslint": {
+      "resolved": "../../node_modules/.pnpm/typescript-eslint@8.53.0_eslint@9.39.2_jiti@2.6.1__typescript@5.9.3/node_modules/typescript-eslint",
+      "link": true
+    },
+    "node_modules/vite": {
+      "resolved": "../../node_modules/.pnpm/vite@7.3.1_@types+node@24.10.7_jiti@2.6.1_lightningcss@1.30.2_tsx@4.21.0_yaml@2.8.2/node_modules/vite",
+      "link": true
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^19.2.0",
     "react-i18next": "^16.5.4",
     "react-router-dom": "^7.13.1",
+    "socket.io-client": "^4.8.3",
     "styled-components": "^6.3.11"
   },
   "devDependencies": {

--- a/apps/frontend/src/api/RacesApi.ts
+++ b/apps/frontend/src/api/RacesApi.ts
@@ -34,4 +34,13 @@ export const RacesApi = {
     }
     return res.json()
   },
+
+  update: async (id: string, data: Partial<Race>): Promise<Race> => {
+    const res = await fetch(`${API_URL}/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    return res.json()
+  },
 }

--- a/apps/frontend/src/components/molecules/EditRaceModal/DriverChips.styles.ts
+++ b/apps/frontend/src/components/molecules/EditRaceModal/DriverChips.styles.ts
@@ -1,0 +1,66 @@
+import styled from 'styled-components'
+
+export const DriverChipsContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px;
+  min-height: 52px;
+  border: 2px solid #334466;
+  border-radius: 4px;
+  background-color: rgba(0, 8, 51, 0.8);
+  cursor: text;
+
+  &:focus-within {
+    border-color: #FF1D44;
+    box-shadow: 0 0 20px rgba(255, 29, 68, 0.3);
+  }
+`
+
+export const DriverChip = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  background: linear-gradient(180deg, #FF1D44 0%, #CC1536 100%);
+  border-radius: 16px;
+  font-size: 13px;
+  color: #fff;
+  font-family: 'Hanken Grotesk', sans-serif;
+`
+
+export const RemoveChipButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  background: rgba(255, 255, 255, 0.2);
+  border: none;
+  border-radius: 50%;
+  color: #fff;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.3);
+  }
+`
+
+export const DriverInput = styled.input`
+  flex: 1;
+  min-width: 120px;
+  padding: 4px;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: 14px;
+  color: #fff;
+  font-family: 'Hanken Grotesk', sans-serif;
+
+  &::placeholder {
+    color: #556677;
+  }
+`

--- a/apps/frontend/src/components/molecules/EditRaceModal/DriverChips.tsx
+++ b/apps/frontend/src/components/molecules/EditRaceModal/DriverChips.tsx
@@ -1,0 +1,73 @@
+import { useState, useRef, KeyboardEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  DriverChipsContainer,
+  DriverChip,
+  RemoveChipButton,
+  DriverInput
+} from './DriverChips.styles'
+
+interface DriverChipsProps {
+  drivers: string[]
+  onChange: (drivers: string[]) => void
+  placeholder?: string
+}
+
+export function DriverChips({ drivers, onChange, placeholder }: DriverChipsProps) {
+  const { t } = useTranslation('raceDetails')
+  const [inputValue, setInputValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const addDriver = (name: string) => {
+    const trimmedName = name.trim()
+    if (trimmedName && !drivers.includes(trimmedName)) {
+      onChange([...drivers, trimmedName])
+    }
+    setInputValue('')
+  }
+
+  const removeDriver = (name: string) => {
+    onChange(drivers.filter(d => d !== name))
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      addDriver(inputValue)
+    } else if (e.key === 'Backspace' && inputValue === '' && drivers.length > 0) {
+      removeDriver(drivers[drivers.length - 1])
+    }
+  }
+
+  const handleContainerClick = () => {
+    inputRef.current?.focus()
+  }
+
+  return (
+    <DriverChipsContainer onClick={handleContainerClick}>
+      {drivers.map(driver => (
+        <DriverChip key={driver}>
+          {driver}
+          <RemoveChipButton
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation()
+              removeDriver(driver)
+            }}
+          >
+            ×
+          </RemoveChipButton>
+        </DriverChip>
+      ))}
+      <DriverInput
+        ref={inputRef}
+        type="text"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={() => inputValue.trim() && addDriver(inputValue)}
+        placeholder={drivers.length === 0 ? (placeholder || t('driversPlaceholder')) : ''}
+      />
+    </DriverChipsContainer>
+  )
+}

--- a/apps/frontend/src/components/molecules/EditRaceModal/EditRaceModal.styles.ts
+++ b/apps/frontend/src/components/molecules/EditRaceModal/EditRaceModal.styles.ts
@@ -1,0 +1,144 @@
+import styled from 'styled-components'
+
+export const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+`
+
+export const ModalContent = styled.div`
+  background: linear-gradient(180deg, #000833 0%, #001244 100%);
+  padding: 24px;
+  border-radius: 12px;
+  max-width: 500px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+`
+
+export const ModalTitle = styled.h2`
+  margin: 0 0 20px;
+  font-size: 20px;
+  color: #fff;
+  font-family: 'Hanken Grotesk', sans-serif;
+`
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`
+
+export const FormRow = styled.div`
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+
+  @media (max-width: 500px) {
+    flex-direction: column;
+  }
+`
+
+export const FormGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+  min-width: 140px;
+`
+
+export const Label = styled.label`
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+  font-family: 'Hanken Grotesk', sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+`
+
+export const Input = styled.input`
+  font-family: 'Hanken Grotesk', sans-serif;
+  padding: 10px 14px;
+  font-size: 14px;
+  border: 2px solid #334466;
+  border-radius: 4px;
+  background-color: rgba(0, 8, 51, 0.8);
+  color: #fff;
+  outline: none;
+  transition: all 0.3s ease;
+
+  &::placeholder {
+    color: #556677;
+  }
+
+  &:focus {
+    border-color: #FF1D44;
+    box-shadow: 0 0 20px rgba(255, 29, 68, 0.3);
+  }
+
+  &[type="date"]::-webkit-calendar-picker-indicator {
+    filter: invert(1);
+  }
+`
+
+export const DriversTextarea = styled.textarea`
+  font-family: 'Hanken Grotesk', sans-serif;
+  padding: 10px 14px;
+  font-size: 14px;
+  border: 2px solid #334466;
+  border-radius: 4px;
+  background-color: rgba(0, 8, 51, 0.8);
+  color: #fff;
+  outline: none;
+  resize: vertical;
+  min-height: 80px;
+  transition: all 0.3s ease;
+
+  &::placeholder {
+    color: #556677;
+  }
+
+  &:focus {
+    border-color: #FF1D44;
+    box-shadow: 0 0 20px rgba(255, 29, 68, 0.3);
+  }
+`
+
+export const ModalButtons = styled.div`
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 8px;
+`
+
+export const ErrorText = styled.span`
+  font-size: 12px;
+  color: #FF1D44;
+  font-family: 'Hanken Grotesk', sans-serif;
+`
+
+export const InputWithUnit = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+`
+
+export const InputUnit = styled.span`
+  position: absolute;
+  right: 12px;
+  font-size: 14px;
+  color: #556677;
+  font-family: 'Hanken Grotesk', sans-serif;
+  pointer-events: none;
+`
+
+export const InputWithUnitStyle = styled(Input)`
+  padding-right: 40px;
+`

--- a/apps/frontend/src/components/molecules/EditRaceModal/EditRaceModal.tsx
+++ b/apps/frontend/src/components/molecules/EditRaceModal/EditRaceModal.tsx
@@ -1,0 +1,315 @@
+import { useState, useEffect, useRef } from 'react'
+import { TextButton } from 'components/atoms/TextButton/TextButton'
+import { useTranslation } from 'react-i18next'
+import { type Race } from 'types/Race'
+import {
+  Overlay,
+  ModalContent,
+  ModalTitle,
+  Form,
+  FormRow,
+  FormGroup,
+  Label,
+  Input,
+  ModalButtons,
+  ErrorText,
+  InputWithUnit,
+  InputUnit,
+  InputWithUnitStyle
+} from './EditRaceModal.styles'
+import { DriverChips } from './DriverChips'
+
+interface EditRaceModalProps {
+  isOpen: boolean
+  race: Race
+  onConfirm: (updatedRace: Partial<Race>) => void
+  onCancel: () => void
+}
+
+interface FormErrors {
+  name?: string
+  startDate?: string
+  raceLength?: string
+  tireSets?: string
+  avgLapTime?: string
+  avgFuelPerLap?: string
+  avgStintTime?: string
+  drivers?: string
+}
+
+function getInitialFormData(race: Race) {
+  return {
+    name: race.name || '',
+    startDate: race.startDate ? new Date(race.startDate).toISOString().split('T')[0] : '',
+    raceLength: race.raceLength?.toString() || '',
+    tireSets: race.tireSets?.toString() || '',
+    avgLapTime: race.avgLapTime ? formatLapTime(race.avgLapTime) : '',
+    avgFuelPerLap: race.avgFuelPerLap?.toString() || '',
+    avgStintTime: race.avgStintTime?.toString() || '',
+    drivers: race.drivers || []
+  }
+}
+
+function formatLapTime(seconds: number): string {
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  const ms = Math.round((seconds % 1) * 1000)
+  return `${mins}:${secs.toString().padStart(2, '0')}:${ms.toString().padStart(3, '0')}`
+}
+
+function parseLapTime(value: string): number | null {
+  const match = value.match(/^(\d+):(\d{1,2}):(\d{1,3})$/)
+  if (!match) return null
+  const mins = parseInt(match[1], 10)
+  const secs = parseInt(match[2], 10)
+  const ms = parseInt(match[3].padEnd(3, '0'), 10)
+  if (secs >= 60) return null
+  return mins * 60 + secs + ms / 1000
+}
+
+function validateForm(formData: ReturnType<typeof getInitialFormData>): FormErrors {
+  const errors: FormErrors = {}
+
+  if (!formData.name.trim()) {
+    errors.name = 'validation.required'
+  }
+
+  if (!formData.startDate) {
+    errors.startDate = 'validation.required'
+  } else {
+    const selectedDate = new Date(formData.startDate)
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    if (selectedDate < today) {
+      errors.startDate = 'validation.futureDate'
+    }
+  }
+
+  if (!formData.raceLength.trim()) {
+    errors.raceLength = 'validation.required'
+  } else if (Number(formData.raceLength) <= 0) {
+    errors.raceLength = 'validation.positiveNumber'
+  }
+
+  if (!formData.tireSets.trim()) {
+    errors.tireSets = 'validation.required'
+  } else if (Number(formData.tireSets) < 0) {
+    errors.tireSets = 'validation.nonNegativeNumber'
+  }
+
+  if (!formData.avgLapTime.trim()) {
+    errors.avgLapTime = 'validation.required'
+  } else if (parseLapTime(formData.avgLapTime) === null) {
+    errors.avgLapTime = 'validation.lapTimeFormat'
+  }
+
+  if (!formData.avgFuelPerLap.trim()) {
+    errors.avgFuelPerLap = 'validation.required'
+  } else if (Number(formData.avgFuelPerLap) < 0) {
+    errors.avgFuelPerLap = 'validation.nonNegativeNumber'
+  }
+
+  if (!formData.avgStintTime.trim()) {
+    errors.avgStintTime = 'validation.required'
+  } else if (Number(formData.avgStintTime) < 0) {
+    errors.avgStintTime = 'validation.nonNegativeNumber'
+  }
+
+  if (!formData.drivers || formData.drivers.length === 0) {
+    errors.drivers = 'validation.required'
+  }
+
+  return errors
+}
+
+export function EditRaceModal({ isOpen, race, onConfirm, onCancel }: EditRaceModalProps) {
+  const { t } = useTranslation('raceDetails')
+  const cancelRef = useRef<HTMLButtonElement>(null)
+  const formRef = useRef<HTMLFormElement>(null)
+  const [formData, setFormData] = useState(getInitialFormData(race))
+  const [errors, setErrors] = useState<FormErrors>({})
+
+  useEffect(() => {
+    if (isOpen) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setFormData(getInitialFormData(race))
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setErrors({})
+    }
+  }, [isOpen, race])
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!isOpen) return
+      if (e.key === 'Escape') {
+        onCancel()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onCancel])
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const formErrors = validateForm(formData)
+    setErrors(formErrors)
+
+    if (Object.keys(formErrors).length > 0) {
+      return
+    }
+
+    const lapTime = parseLapTime(formData.avgLapTime)
+
+    onConfirm({
+      name: formData.name.trim(),
+      startDate: new Date(formData.startDate),
+      raceLength: Number(formData.raceLength),
+      tireSets: Number(formData.tireSets),
+      avgLapTime: lapTime,
+      avgFuelPerLap: Number(formData.avgFuelPerLap),
+      avgStintTime: Number(formData.avgStintTime),
+      drivers: formData.drivers
+    })
+  }
+
+  const handleChange = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData(prev => ({ ...prev, [field]: e.target.value }))
+    if (errors[field as keyof FormErrors]) {
+      setErrors(prev => ({ ...prev, [field]: undefined }))
+    }
+  }
+
+  const handleDriversChange = (drivers: string[]) => {
+    setFormData(prev => ({ ...prev, drivers }))
+    if (errors.drivers) {
+      setErrors(prev => ({ ...prev, drivers: undefined }))
+    }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <Overlay onClick={onCancel}>
+      <ModalContent onClick={(e) => e.stopPropagation()}>
+        <ModalTitle>{t('editRace')}</ModalTitle>
+        <Form ref={formRef} onSubmit={handleSubmit}>
+          <FormGroup>
+            <Label>{t('name')}</Label>
+            <Input
+              type="text"
+              value={formData.name}
+              onChange={handleChange('name')}
+              placeholder={t('namePlaceholder')}
+            />
+            {errors.name && <ErrorText>{t(errors.name)}</ErrorText>}
+          </FormGroup>
+
+          <FormRow>
+            <FormGroup>
+              <Label>{t('startDate')}</Label>
+              <Input
+                type="date"
+                value={formData.startDate}
+                onChange={handleChange('startDate')}
+              />
+              {errors.startDate && <ErrorText>{t(errors.startDate)}</ErrorText>}
+            </FormGroup>
+
+            <FormGroup>
+              <Label>{t('raceLength')}</Label>
+              <InputWithUnit>
+                <InputWithUnitStyle
+                  type="number"
+                  value={formData.raceLength}
+                  onChange={handleChange('raceLength')}
+                  placeholder="6"
+                  min="0"
+                  step="0.1"
+                />
+                <InputUnit>h</InputUnit>
+              </InputWithUnit>
+              {errors.raceLength && <ErrorText>{t(errors.raceLength)}</ErrorText>}
+            </FormGroup>
+          </FormRow>
+
+          <FormRow>
+            <FormGroup>
+              <Label>{t('tireSets')}</Label>
+              <Input
+                type="number"
+                value={formData.tireSets}
+                onChange={handleChange('tireSets')}
+                placeholder="30"
+                min="0"
+              />
+              {errors.tireSets && <ErrorText>{t(errors.tireSets)}</ErrorText>}
+            </FormGroup>
+
+            <FormGroup>
+              <Label>{t('avgLapTime')}</Label>
+              <Input
+                type="text"
+                value={formData.avgLapTime}
+                onChange={handleChange('avgLapTime')}
+                placeholder="1:35:000"
+              />
+              {errors.avgLapTime && <ErrorText>{t(errors.avgLapTime)}</ErrorText>}
+            </FormGroup>
+          </FormRow>
+
+          <FormRow>
+            <FormGroup>
+              <Label>{t('avgFuelPerLap')}</Label>
+              <InputWithUnit>
+                <InputWithUnitStyle
+                  type="number"
+                  value={formData.avgFuelPerLap}
+                  onChange={handleChange('avgFuelPerLap')}
+                  placeholder="4.5"
+                  min="0"
+                  step="0.1"
+                />
+                <InputUnit>%</InputUnit>
+              </InputWithUnit>
+              {errors.avgFuelPerLap && <ErrorText>{t(errors.avgFuelPerLap)}</ErrorText>}
+            </FormGroup>
+
+            <FormGroup>
+              <Label>{t('avgStintTime')}</Label>
+              <InputWithUnit>
+                <InputWithUnitStyle
+                  type="number"
+                  value={formData.avgStintTime}
+                  onChange={handleChange('avgStintTime')}
+                  placeholder="42"
+                  min="0"
+                />
+                <InputUnit>min</InputUnit>
+              </InputWithUnit>
+              {errors.avgStintTime && <ErrorText>{t(errors.avgStintTime)}</ErrorText>}
+            </FormGroup>
+          </FormRow>
+
+          <FormGroup>
+            <Label>{t('drivers')}</Label>
+            <DriverChips
+              drivers={formData.drivers}
+              onChange={handleDriversChange}
+              placeholder={t('driversPlaceholder')}
+            />
+            {errors.drivers && <ErrorText>{t(errors.drivers)}</ErrorText>}
+          </FormGroup>
+
+          <ModalButtons>
+            <TextButton type="button" $variant="secondary" ref={cancelRef} onClick={onCancel}>
+              {t('cancel')}
+            </TextButton>
+            <TextButton type="submit">
+              {t('save')}
+            </TextButton>
+          </ModalButtons>
+        </Form>
+      </ModalContent>
+    </Overlay>
+  )
+}

--- a/apps/frontend/src/hooks/useSocket.tsx
+++ b/apps/frontend/src/hooks/useSocket.tsx
@@ -1,0 +1,65 @@
+import { createContext, useContext, useEffect, useState, useCallback, useRef, type ReactNode } from 'react'
+import { io, type Socket } from 'socket.io-client'
+import { type Race } from 'types/Race'
+
+interface SocketContextType {
+  socket: Socket | null
+  isConnected: boolean
+  onRaceUpdated: (callback: (race: Race) => void) => () => void
+}
+
+const SocketContext = createContext<SocketContextType>({
+  socket: null,
+  isConnected: false,
+  onRaceUpdated: () => () => {}
+})
+
+export function SocketProvider({ children }: { children: ReactNode }) {
+  const [socket, setSocket] = useState<Socket | null>(null)
+  const [isConnected, setIsConnected] = useState(false)
+  const listenersRef = useRef<Set<(race: Race) => void>>(new Set())
+
+  useEffect(() => {
+    const socketUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000'
+    const newSocket = io(socketUrl, {
+      transports: ['websocket', 'polling']
+    })
+
+    newSocket.on('connect', () => {
+      setIsConnected(true)
+    })
+
+    newSocket.on('disconnect', () => {
+      setIsConnected(false)
+    })
+
+    newSocket.on('race:updated', (race: Race) => {
+      listenersRef.current.forEach(callback => callback(race))
+    })
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSocket(newSocket)
+
+    return () => {
+      newSocket.disconnect()
+    }
+  }, [])
+
+  const onRaceUpdated = useCallback((callback: (race: Race) => void) => {
+    listenersRef.current.add(callback)
+
+    return () => {
+      listenersRef.current.delete(callback)
+    }
+  }, [])
+
+  return (
+    <SocketContext.Provider value={{ socket, isConnected, onRaceUpdated }}>
+      {children}
+    </SocketContext.Provider>
+  )
+}
+
+export function useSocket() {
+  return useContext(SocketContext)
+}

--- a/apps/frontend/src/i18n/locales/en/race-details.json
+++ b/apps/frontend/src/i18n/locales/en/race-details.json
@@ -31,5 +31,17 @@
   "tireSets": "Tires",
   "avgLapTime": "Avg lap time",
   "avgFuelPerLap": "Avg fuel per lap",
-  "avgStintTime": "Avg stint time"
+  "avgStintTime": "Avg stint time",
+  "name": "Name",
+  "namePlaceholder": "Enter race name",
+  "driversPlaceholder": "Enter driver names separated by commas",
+  "cancel": "Cancel",
+  "save": "Save",
+  "validation": {
+    "required": "Field is required",
+    "futureDate": "Date must be in the future",
+    "lapTimeFormat": "Format: min:sec:ms (e.g. 1:35:000)",
+    "positiveNumber": "Value must be greater than 0",
+    "nonNegativeNumber": "Value cannot be negative"
+  }
 }

--- a/apps/frontend/src/i18n/locales/pl/race-details.json
+++ b/apps/frontend/src/i18n/locales/pl/race-details.json
@@ -28,8 +28,20 @@
   "notesPlaceholder": "Dodaj notatki do wyścigu...",
   "raceLength": "Długość wyścigu",
   "drivers": "Kierowcy",
-  "tireSets": "Opony",
+  "tireSets": "Zestawy opon",
   "avgLapTime": "Śr. czas okrążenia",
   "avgFuelPerLap": "Śr. zużycie paliwa",
-  "avgStintTime": "Śr. czas stintu"
+  "avgStintTime": "Śr. czas stintu",
+  "name": "Nazwa",
+  "namePlaceholder": "Wpisz nazwę wyścigu",
+  "driversPlaceholder": "Wpisz imiona kierowców oddzielone przecinkami",
+  "cancel": "Anuluj",
+  "save": "Zapisz",
+  "validation": {
+    "required": "Pole wymagane",
+    "futureDate": "Data musi być w przyszłości",
+    "lapTimeFormat": "Format: min:sek:ms (np. 1:35:000)",
+    "positiveNumber": "Wartość musi być większa od 0",
+    "nonNegativeNumber": "Wartość nie może być ujemna"
+  }
 }

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { ThemeProvider } from 'styled-components'
 import { GlobalStyles, theme } from 'styles/theme'
+import { SocketProvider } from '@/hooks/useSocket'
 import 'i18n/i18n'
 import App from '@/App'
 
@@ -11,7 +12,9 @@ createRoot(document.getElementById('root')!).render(
     <ThemeProvider theme={theme}>
       <GlobalStyles />
       <BrowserRouter>
-        <App />
+        <SocketProvider>
+          <App />
+        </SocketProvider>
       </BrowserRouter>
     </ThemeProvider>
   </StrictMode>,

--- a/apps/frontend/src/pages/RaceDetailsPage.tsx
+++ b/apps/frontend/src/pages/RaceDetailsPage.tsx
@@ -6,10 +6,20 @@ import { Loader } from 'components/atoms/Loader/Loader'
 import { BodyM } from 'components/atoms/Typography/Typography.styles'
 import { IconTextButton } from 'components/atoms/IconTextButton/IconTextButton'
 import { StintSchedule } from 'components/molecules/StintSchedule/StintSchedule'
+import { EditRaceModal } from 'components/molecules/EditRaceModal/EditRaceModal'
 import { RacesApi } from 'api/RacesApi'
+import { useSocket } from '@/hooks/useSocket'
 import { type Race } from 'types/Race'
 import ArrowBackIcon from 'assets/svg/arrow-back.svg'
 import EditIcon from 'assets/svg/edit.svg'
+
+function formatLapTimeDisplay(seconds: number | undefined): string {
+  if (!seconds) return '-'
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  const ms = Math.round((seconds % 1) * 1000)
+  return `${mins}:${secs.toString().padStart(2, '0')}:${ms.toString().padStart(3, '0')}`
+}
 
 export function RaceDetailsPage() {
   const { id } = useParams<{ id: string }>()
@@ -18,6 +28,8 @@ export function RaceDetailsPage() {
   const [race, setRace] = useState<Race | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false)
+  const { onRaceUpdated } = useSocket()
 
   useEffect(() => {
     const fetchRace = async () => {
@@ -25,16 +37,8 @@ export function RaceDetailsPage() {
       setLoading(true)
       try {
         const data = await RacesApi.getById(id)
-        setRace({
-          ...data,
-          raceLength: 6,
-          drivers: ['Max Verstappen', 'Sergio Perez'],
-          tireSets: 30,
-          avgLapTime: 95,
-          avgFuelPerLap: 4.5,
-          avgStintTime: 42
-        })
-      } catch (err) {
+        setRace(data)
+      } catch {
         setError(t('failedToLoad'))
       } finally {
         setLoading(false)
@@ -42,6 +46,29 @@ export function RaceDetailsPage() {
     }
     fetchRace()
   }, [id, t])
+
+  useEffect(() => {
+    if (!id) return
+
+    const unsubscribe = onRaceUpdated((updatedRace) => {
+      if (updatedRace._id === id) {
+        setRace(updatedRace)
+      }
+    })
+
+    return unsubscribe
+  }, [id, onRaceUpdated])
+
+  const handleSaveRace = async (updatedData: Partial<Race>) => {
+    if (!id || !race) return
+    try {
+      const updatedRace = await RacesApi.update(id, updatedData)
+      setRace(updatedRace)
+      setIsEditModalOpen(false)
+    } catch {
+      console.error('Failed to update race')
+    }
+  }
 
   if (loading) {
     return (
@@ -70,7 +97,7 @@ export function RaceDetailsPage() {
       </IconTextButton>
       <IconTextButton 
         icon={EditIcon} 
-        onClick={() => console.log('Edit race')} 
+        onClick={() => setIsEditModalOpen(true)} 
         style={{ position: 'absolute', top: '1rem', right: '1rem' }}
       >
         {t('editRace')}
@@ -83,7 +110,7 @@ export function RaceDetailsPage() {
             <BodyM>{t('startDate')}: {race.startDate ? new Date(race.startDate).toLocaleDateString('pl-PL') : t('notSet')}</BodyM>
             <BodyM>{t('raceLength')}: {race.raceLength}h</BodyM>
             <BodyM>{t('tireSets')}: {race.tireSets}</BodyM>
-            <BodyM>{t('avgLapTime')}: 1:35:000</BodyM>
+            <BodyM>{t('avgLapTime')}: {formatLapTimeDisplay(race.avgLapTime)}</BodyM>
             <BodyM>{t('avgFuelPerLap')}: {race.avgFuelPerLap}%</BodyM>
             <BodyM>{t('avgStintTime')}: {race.avgStintTime} min</BodyM>
             <BodyM>{t('drivers')}: {race.drivers.join(', ')}</BodyM>
@@ -91,6 +118,15 @@ export function RaceDetailsPage() {
         </HeaderLeft>
       </HeaderRow>
       <StintSchedule />
+      {race && (
+        <EditRaceModal
+          key={isEditModalOpen ? 'open' : 'closed'}
+          isOpen={isEditModalOpen}
+          race={race}
+          onConfirm={handleSaveRace}
+          onCancel={() => setIsEditModalOpen(false)}
+        />
+      )}
     </RaceDetailsContainer>
   )
 }

--- a/apps/frontend/tsconfig.app.json
+++ b/apps/frontend/tsconfig.app.json
@@ -34,7 +34,8 @@
       "assets/*": ["./src/assets/*"],
       "types/*": ["./src/types/*"],
       "styles/*": ["./src/styles/*"],
-      "i18n/*": ["./src/i18n/*"]
+      "i18n/*": ["./src/i18n/*"],
+      "hooks/*": ["./src/hooks/*"]
     }
   },
   "include": ["src"]


### PR DESCRIPTION
## Summary
- Dodano modal edycji szczegółów wyścigu z walidacją
- Pola: nazwa, data startu, długość, opony, śr. czas okrążenia, zużycie paliwa, czas stintu, kierowcy
- Kierowcy jako chipsy z możliwością dodawania/usuwania
- Walidacja: wszystkie pola wymagane, format czasu okrążenia (min:sek:ms), data w przyszłości
- WebSocket real-time sync - zmiany aktualizują się u wszystkich użytkowników

## Backend
- Rozszerzony model Race o nowe pola
- Endpoint PATCH /api/races/:id
- Socket event race:updated

## Frontend
- EditRaceModal component
- DriverChips component
- useSocket hook dla WebSocket
- SocketProvider w App