### PR TITLE
fix: update stints when avgStintTime changes

### DIFF
--- a/apps/backend/src/routes/race.routes.ts
+++ b/apps/backend/src/routes/race.routes.ts
@@ -1,5 +1,7 @@
 import {FastifyInstance} from "fastify";
 import {Race} from "../models/Race.js";
+import {Schedule} from "../models/Schedule.js";
+import {Stint} from "../models/Stint.js";
 import {getIO} from "../socket.js";
 
 export default async function raceRoutes(app: FastifyInstance) {
@@ -41,6 +43,13 @@ export default async function raceRoutes(app: FastifyInstance) {
         if (patch.notes && patch.notes.length > 200) {
             return reply.status(400).send({ error: "Notatka może mieć maksymalnie 200 znaków" });
         }
+
+        const oldRace = await Race.findById(id);
+        if (!oldRace) {
+            return reply.status(404).send({ error: "Wyścig nie znaleziony" });
+        }
+
+        const oldAvgStintTime = oldRace.avgStintTime;
         
         const race = await Race.findByIdAndUpdate(
             id,
@@ -50,6 +59,21 @@ export default async function raceRoutes(app: FastifyInstance) {
         
         if (!race) {
             return reply.status(404).send({ error: "Wyścig nie znaleziony" });
+        }
+
+        if (patch.avgStintTime !== undefined && patch.avgStintTime !== oldAvgStintTime && oldAvgStintTime > 0) {
+            const schedule = await Schedule.findOne({ raceId: id });
+            if (schedule) {
+                await Stint.updateMany(
+                    { scheduleId: schedule._id, duration: oldAvgStintTime },
+                    { $set: { duration: patch.avgStintTime } }
+                );
+
+                const io = getIO();
+                if (io) {
+                    io.emit("stint:refresh", { raceId: id });
+                }
+            }
         }
 
         const io = getIO();


### PR DESCRIPTION
## Summary
- When changing avgStintTime in race data, all stints with duration equal to the previous avgStintTime are now updated to the new value
- Emits stint:refresh event to update frontend after changes