### PR TITLE
feat: add pitstop time calculation with fuel tank capacity

### DIFF
--- a/apps/backend/src/models/Race.ts
+++ b/apps/backend/src/models/Race.ts
@@ -8,6 +8,7 @@ const RaceSchema = new Schema(
         raceLength: { type: Number, default: 6 },
         drivers: [{ type: String }],
         tireSets: { type: Number, default: 0 },
+        fuelTankCapacity: { type: Number, default: 100 },
         avgLapTime: { type: Number, default: 0 },
         avgFuelPerLap: { type: Number, default: 0 },
         avgStintTime: { type: Number, default: 0 },

--- a/apps/backend/src/routes/race.routes.ts
+++ b/apps/backend/src/routes/race.routes.ts
@@ -38,7 +38,7 @@ export default async function raceRoutes(app: FastifyInstance) {
 
     app.patch("/races/:id", async (req, reply) => {
         const { id } = req.params as any;
-        const patch = req.body as { name?: string; startDate?: Date; startTime?: string; raceLength?: number; drivers?: string[]; tireSets?: number; avgLapTime?: number; avgFuelPerLap?: number; avgStintTime?: number; notes?: string; };
+        const patch = req.body as { name?: string; startDate?: Date; startTime?: string; raceLength?: number; drivers?: string[]; tireSets?: number; fuelTankCapacity?: number; avgLapTime?: number; avgFuelPerLap?: number; avgStintTime?: number; notes?: string; };
         
         if (patch.notes && patch.notes.length > 200) {
             return reply.status(400).send({ error: "Notatka może mieć maksymalnie 200 znaków" });

--- a/apps/frontend/src/components/molecules/EditRaceModal/EditRaceModal.tsx
+++ b/apps/frontend/src/components/molecules/EditRaceModal/EditRaceModal.tsx
@@ -31,6 +31,7 @@ interface FormErrors {
   startTime?: string
   raceLength?: string
   tireSets?: string
+  fuelTankCapacity?: string
   avgLapTime?: string
   avgFuelPerLap?: string
   avgStintTime?: string
@@ -44,6 +45,7 @@ function getInitialFormData(race: Race) {
     startTime: race.startTime || '19:30',
     raceLength: race.raceLength?.toString() || '',
     tireSets: race.tireSets?.toString() || '',
+    fuelTankCapacity: race.fuelTankCapacity?.toString() || '',
     avgLapTime: race.avgLapTime ? formatLapTime(race.avgLapTime) : '',
     avgFuelPerLap: race.avgFuelPerLap?.toString() || '',
     avgStintTime: race.avgStintTime?.toString() || '',
@@ -102,6 +104,12 @@ function validateForm(formData: ReturnType<typeof getInitialFormData>): FormErro
     errors.tireSets = 'validation.nonNegativeNumber'
   } else if (Number(formData.tireSets) > 100) {
     errors.tireSets = 'validation.tireSetsRange'
+  }
+
+  if (!formData.fuelTankCapacity.trim()) {
+    errors.fuelTankCapacity = 'validation.required'
+  } else if (Number(formData.fuelTankCapacity) <= 0) {
+    errors.fuelTankCapacity = 'validation.positiveNumber'
   }
 
   if (!formData.avgLapTime.trim()) {
@@ -177,6 +185,7 @@ export function EditRaceModal({ isOpen, race, onConfirm, onCancel }: EditRaceMod
       startTime: formData.startTime,
       raceLength: Number(formData.raceLength),
       tireSets: Number(formData.tireSets),
+      fuelTankCapacity: Number(formData.fuelTankCapacity),
       avgLapTime: lapTime ?? undefined,
       avgFuelPerLap: Number(formData.avgFuelPerLap),
       avgStintTime: Number(formData.avgStintTime),
@@ -275,6 +284,22 @@ export function EditRaceModal({ isOpen, race, onConfirm, onCancel }: EditRaceMod
                 />
               </InputWithUnit>
               {errors.tireSets && <ErrorText>{t(errors.tireSets)}</ErrorText>}
+            </FormGroup>
+
+            <FormGroup>
+              <Label>{t('fuelTankCapacity')}</Label>
+              <InputWithUnit>
+                <InputWithUnitStyle
+                  type="number"
+                  value={formData.fuelTankCapacity}
+                  onChange={handleChange('fuelTankCapacity')}
+                  placeholder="100"
+                  min="1"
+                  step="1"
+                />
+                <InputUnit>L</InputUnit>
+              </InputWithUnit>
+              {errors.fuelTankCapacity && <ErrorText>{t(errors.fuelTankCapacity)}</ErrorText>}
             </FormGroup>
 
             <FormGroup>

--- a/apps/frontend/src/components/molecules/StintSchedule/StintSchedule.tsx
+++ b/apps/frontend/src/components/molecules/StintSchedule/StintSchedule.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { type Stint } from 'types/Schedule'
+import { calculatePitstopTime } from '@/hooks/usePitstopTime'
 import { IconButton } from 'components/atoms/IconButton/IconButton'
 import { TextButton } from 'components/atoms/TextButton/TextButton'
 import { useSocket } from '@/hooks/useSocket'
@@ -43,10 +44,11 @@ const CheckIcon = () => (
 
 function formatTime(minutes: number, startTime: string): string {
   const [hours, mins] = startTime.split(':').map(Number)
-  const totalMinutes = hours * 60 + mins + minutes
+  const totalMinutes = hours * 60 + mins + Math.floor(minutes)
   const newHours = Math.floor(totalMinutes / 60) % 24
   const newMins = totalMinutes % 60
-  return `${newHours.toString().padStart(2, '0')}:${newMins.toString().padStart(2, '0')}`
+  const secs = Math.round((minutes % 1) * 60)
+  return `${newHours.toString().padStart(2, '0')}:${newMins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
 }
 
 function formatDuration(minutes: number): string {
@@ -79,10 +81,11 @@ interface StintScheduleProps {
   raceId: string
   startTime: string
   tireSets: number
+  fuelTankCapacity: number
   notes?: string
 }
 
-export function StintSchedule({ drivers, avgStintTime, avgLapTime, raceId, startTime, tireSets, notes: initialNotes }: StintScheduleProps) {
+export function StintSchedule({ drivers, avgStintTime, avgLapTime, raceId, startTime, tireSets, fuelTankCapacity, notes: initialNotes }: StintScheduleProps) {
   const { t } = useTranslation('raceDetails')
   const { onStintRefresh } = useSocket()
   const [stints, setStints] = useState<Stint[]>([])
@@ -215,7 +218,13 @@ export function StintSchedule({ drivers, avgStintTime, avgLapTime, raceId, start
           </TableHead>
           <TableBody>
             {stints.map((stint, index) => {
-              const stintStartTime = stints.slice(0, index).reduce((sum, s) => sum + s.duration, 0)
+              let stintStartTime = 0
+              for (let i = 0; i < index; i++) {
+                stintStartTime += stints[i].duration
+                if (i < stints.length - 1) {
+                  stintStartTime += calculatePitstopTime(stints[i], stints[i + 1], fuelTankCapacity) / 60
+                }
+              }
               const stintEndTime = stintStartTime + stint.duration
               const isActive = isStintActive(stintStartTime, stint.duration)
               const displayTires = getTiresAtIndex(stints, index, tireSets)

--- a/apps/frontend/src/hooks/usePitstopTime.ts
+++ b/apps/frontend/src/hooks/usePitstopTime.ts
@@ -1,0 +1,61 @@
+import { type Stint } from 'types/Schedule'
+
+const FUEL_FILL_RATE = 3.0
+const FUEL_RANDOM_DELAY = 2.0
+const TIME_INSERT_NOZZLE = 1.2
+const TIME_REMOVE_NOZZLE = 0.7
+const CONCURRENT_FUEL_TIRES = 1.0
+const TIME_TWO_TIRES = 15.0
+const TIME_FOUR_TIRES = 32.0
+const TIRE_RANDOM_DELAY = 7.0
+const CONCURRENT_TIRES = 1.0
+const TIME_DRIVER_CHANGE = 40.0
+const DRIVER_RANDOM_DELAY = 6.0
+const CONCURRENT_DRIVER = 1.0
+
+export function calculatePitstopTime(previousStint: Stint | null, currentStint: Stint, fuelTankCapacity: number = 100): number {
+  if (!previousStint) return 0
+
+  let pitstopTime = 0
+
+  const fuelAmount = ((currentStint.fuel - 1) / 100) * fuelTankCapacity
+  const fuelTime = (fuelAmount / FUEL_FILL_RATE) + FUEL_RANDOM_DELAY + TIME_INSERT_NOZZLE + TIME_REMOVE_NOZZLE
+
+  const changedTires = [
+    currentStint.tireFL !== '-' ? 1 : 0,
+    currentStint.tireFR !== '-' ? 1 : 0,
+    currentStint.tireRL !== '-' ? 1 : 0,
+    currentStint.tireRR !== '-' ? 1 : 0
+  ].reduce((sum, v) => sum + v, 0)
+  
+  let tireTime = 0
+  if (changedTires > 0) {
+    let baseTireTime: number
+    if (CONCURRENT_TIRES === 1.0) {
+      baseTireTime = changedTires <= 2 ? TIME_TWO_TIRES : TIME_FOUR_TIRES
+    } else {
+      baseTireTime = changedTires * TIME_TWO_TIRES
+    }
+    tireTime = baseTireTime + TIRE_RANDOM_DELAY
+  }
+
+  const driverChanged = currentStint.driver !== previousStint.driver
+  const driverTime = driverChanged ? TIME_DRIVER_CHANGE + DRIVER_RANDOM_DELAY : 0
+
+  const fuelAndTiresConcurrent = CONCURRENT_FUEL_TIRES === 1.0
+  let mainPitstopTime: number
+  
+  if (fuelAndTiresConcurrent && changedTires > 0) {
+    mainPitstopTime = Math.max(fuelTime, tireTime)
+  } else {
+    mainPitstopTime = fuelTime + tireTime
+  }
+
+  if (driverChanged && CONCURRENT_DRIVER === 1.0) {
+    pitstopTime = Math.max(mainPitstopTime, driverTime)
+  } else {
+    pitstopTime = mainPitstopTime + driverTime
+  }
+
+  return pitstopTime
+}

--- a/apps/frontend/src/i18n/locales/en/race-details.json
+++ b/apps/frontend/src/i18n/locales/en/race-details.json
@@ -34,6 +34,7 @@
   "raceLength": "Race length",
   "drivers": "Drivers",
   "tireSets": "Number of tires",
+  "fuelTankCapacity": "Fuel tank capacity",
   "avgLapTime": "Avg lap time",
   "avgFuelPerLap": "Avg fuel per lap",
   "avgStintTime": "Avg stint time",

--- a/apps/frontend/src/i18n/locales/pl/race-details.json
+++ b/apps/frontend/src/i18n/locales/pl/race-details.json
@@ -34,6 +34,7 @@
   "raceLength": "Długość wyścigu",
   "drivers": "Kierowcy",
   "tireSets": "Liczba opon",
+  "fuelTankCapacity": "Pojemność baku",
   "avgLapTime": "Śr. czas okrążenia",
   "avgFuelPerLap": "Śr. zużycie paliwa",
   "avgStintTime": "Śr. czas stintu",

--- a/apps/frontend/src/pages/RaceDetailsPage.tsx
+++ b/apps/frontend/src/pages/RaceDetailsPage.tsx
@@ -110,6 +110,7 @@ export function RaceDetailsPage() {
             <BodyM>{t('startDate')}: {race.startDate ? new Date(race.startDate).toLocaleDateString('pl-PL') + ' ' + (race.startTime || '19:30') : t('notSet')}</BodyM>
             <BodyM>{t('raceLength')}: {race.raceLength}h</BodyM>
             <BodyM>{t('tireSets')}: {race.tireSets}</BodyM>
+            <BodyM>{t('fuelTankCapacity')}: {race.fuelTankCapacity}L</BodyM>
             <BodyM>{t('avgLapTime')}: {formatLapTimeDisplay(race.avgLapTime)}</BodyM>
             <BodyM>{t('avgFuelPerLap')}: {race.avgFuelPerLap}%</BodyM>
             <BodyM>{t('avgStintTime')}: {race.avgStintTime} min</BodyM>
@@ -124,6 +125,7 @@ export function RaceDetailsPage() {
         raceId={race._id} 
         startTime={race.startTime || '19:30'} 
         tireSets={race.tireSets || 0}
+        fuelTankCapacity={race.fuelTankCapacity || 100}
         notes={race.notes}
       />}
       {race && (

--- a/apps/frontend/src/types/Race.ts
+++ b/apps/frontend/src/types/Race.ts
@@ -7,6 +7,7 @@ export interface Race {
   raceLength: number
   drivers: string[]
   tireSets: number
+  fuelTankCapacity: number
   avgLapTime: number
   avgFuelPerLap: number
   avgStintTime: number


### PR DESCRIPTION
## Summary
- Add pitstop time calculation based on fuel, tires, and driver changes
- Add fuel tank capacity field to race configuration
- Display pitstop times between stints in schedule
- Add time format with seconds (hh:mm:ss)