### PR TITLE
feat: add driver total time summary table

### DIFF
--- a/apps/frontend/src/components/molecules/StintSchedule/StintSchedule.styles.ts
+++ b/apps/frontend/src/components/molecules/StintSchedule/StintSchedule.styles.ts
@@ -319,3 +319,67 @@ export const SaveNotesButton = styled.button`
     background: #E0153C;
   }
 `
+
+export const DriverSummaryContainer = styled.div`
+  width: 100%;
+  margin-top: 1.5rem;
+  margin-bottom: 2rem;
+`
+
+export const DriverSummaryTitle = styled.h3`
+  font-family: 'Hanken Grotesk', sans-serif;
+  font-size: 1rem;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 0.75rem;
+`
+
+export const DriverSummaryTable = styled.table`
+  width: 100%;
+  max-width: 400px;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 8px;
+  overflow: hidden;
+`
+
+export const DriverSummaryHead = styled.thead`
+  background: rgba(255, 255, 255, 0.08);
+`
+
+export const DriverSummaryHeader = styled.th`
+  font-family: 'Hanken Grotesk', sans-serif;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.6);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+`
+
+export const DriverSummaryBody = styled.tbody``
+
+export const DriverSummaryRow = styled.tr`
+  &:hover {
+    background: rgba(255, 255, 255, 0.05);
+  }
+`
+
+export const DriverSummaryCell = styled.td`
+  font-family: 'Hanken Grotesk', sans-serif;
+  font-size: 0.9rem;
+  color: #fff;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+`
+
+export const DriverNameCell = styled(DriverSummaryCell)`
+  font-weight: 500;
+`
+
+export const TotalTimeCell = styled(DriverSummaryCell)`
+  color: rgba(255, 255, 255, 0.8);
+`

--- a/apps/frontend/src/components/molecules/StintSchedule/StintSchedule.tsx
+++ b/apps/frontend/src/components/molecules/StintSchedule/StintSchedule.tsx
@@ -31,7 +31,16 @@ import {
   NotesTextarea,
   CharCount,
   NotesFooter,
-  SaveNotesButton
+  SaveNotesButton,
+  DriverSummaryContainer,
+  DriverSummaryTitle,
+  DriverSummaryTable,
+  DriverSummaryHead,
+  DriverSummaryHeader,
+  DriverSummaryBody,
+  DriverSummaryRow,
+  DriverNameCell,
+  TotalTimeCell
 } from './StintSchedule.styles'
 import EditIcon from 'assets/svg/edit.svg'
 import TrashIcon from 'assets/svg/trash.svg'
@@ -53,6 +62,12 @@ function formatTime(minutes: number, startTime: string): string {
 
 function formatDuration(minutes: number): string {
   return `${minutes} min`
+}
+
+function formatTotalTime(minutes: number): string {
+  const hours = Math.floor(minutes / 60)
+  const mins = Math.round(minutes % 60)
+  return `${hours}:${mins.toString().padStart(2, '0')}`
 }
 
 function getTiresAtIndex(stints: Stint[], index: number, tireSets: number): number {
@@ -376,6 +391,36 @@ export function StintSchedule({ drivers, avgStintTime, avgLapTime, raceId, start
           )}
         </NotesFooter>
       </NotesContainer>
+      {stints.length > 0 && drivers.length > 0 && (
+        <DriverSummaryContainer>
+          <DriverSummaryTitle>{t('driverTotalTime')}</DriverSummaryTitle>
+          <DriverSummaryTable>
+            <DriverSummaryHead>
+              <tr>
+                <DriverSummaryHeader>{t('driver')}</DriverSummaryHeader>
+                <DriverSummaryHeader>{t('totalTime')}</DriverSummaryHeader>
+              </tr>
+            </DriverSummaryHead>
+            <DriverSummaryBody>
+              {Object.entries(
+                stints.reduce((acc, stint) => {
+                  if (stint.driver) {
+                    acc[stint.driver] = (acc[stint.driver] || 0) + stint.duration
+                  }
+                  return acc
+                }, {} as Record<string, number>)
+              )
+                .sort(([, a], [, b]) => b - a)
+                .map(([driver, totalMinutes]) => (
+                  <DriverSummaryRow key={driver}>
+                    <DriverNameCell>{driver}</DriverNameCell>
+                    <TotalTimeCell>{formatTotalTime(totalMinutes)}</TotalTimeCell>
+                  </DriverSummaryRow>
+                ))}
+            </DriverSummaryBody>
+          </DriverSummaryTable>
+        </DriverSummaryContainer>
+      )}
     </ScheduleContainer>
   )
 }

--- a/apps/frontend/src/i18n/locales/en/race-details.json
+++ b/apps/frontend/src/i18n/locales/en/race-details.json
@@ -31,6 +31,8 @@
   "notes": "Notes",
   "notesPlaceholder": "Add notes for the race...",
   "saveNotes": "Save",
+  "driverTotalTime": "Total driver time",
+  "totalTime": "Total time",
   "raceLength": "Race length",
   "drivers": "Drivers",
   "tireSets": "Number of tires",

--- a/apps/frontend/src/i18n/locales/pl/race-details.json
+++ b/apps/frontend/src/i18n/locales/pl/race-details.json
@@ -31,6 +31,8 @@
   "notes": "Notatki",
   "notesPlaceholder": "Dodaj notatki do wyścigu...",
   "saveNotes": "Zapisz",
+  "driverTotalTime": "Łączny czas jazdy kierowców",
+  "totalTime": "Łączny czas",
   "raceLength": "Długość wyścigu",
   "drivers": "Kierowcy",
   "tireSets": "Liczba opon",


### PR DESCRIPTION
## Summary
- Add driver total time table under race notes in race details page
- Display total driving time per driver in hh:mm format
- Sort by total time descending
- Reuse styling from stint schedule table